### PR TITLE
Splash page

### DIFF
--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -36,9 +36,6 @@ const SplashPage: React.VFC<SplashPageProps> = ({
     fetchVersion()
   }, [])
 
-  const introMessageNoRoutes = `You’re seeing this because you don’t have any pages yet.`
-  const introMessageRoutes = `You’re seeing this because you don’t have a home page yet.`
-
   return (
     <>
       <main>
@@ -173,28 +170,30 @@ const SplashPage: React.VFC<SplashPageProps> = ({
               margin-top: var(--space-8);
             }
 
-            .page-list {
-              margin-top: var(--space-6);
-              margin-bottom: var(--space-3);
-            }
-
-            code {
-              font-family: Fira Code,Fira Mono,Menlo,Monoco,monospace;
-              font-size: var(--space-4);
-              padding-top: var(--space-0);
-              padding-bottom: var(--space-0);
-              padding-left: var(--space-1);
-              padding-right: var(--space-1);
-              border-radius: var(--space-1);
-              color: var(--highlight-2);
-              background-color: var(--highlight-3);
-            }
-
             .intro-instructions {
               font-size: var(--space-5);
               font-weight: 400;
               line-height: var(--space-7);
               margin-bottom: var(--space-2);
+            }
+
+            code {
+              font-family: Fira Code,Fira Mono,Menlo,Monoco,monospace;
+              font-size: var(--space-4);
+              padding: var(--space-1) var(--space-2);
+              border-radius: var(--space-1);
+              color: var(--highlight-2);
+              background-color: var(--highlight-3);
+            }
+
+            .page-list {
+              margin: var(--space-2) 0;
+              padding: 0;
+              list-style-type: none;
+            }
+
+            .page-item {
+              margin: var(--space-4) 0;
             }
 
             /* Resources */
@@ -308,47 +307,54 @@ const SplashPage: React.VFC<SplashPageProps> = ({
                       fill="var(--highlight-1)"
                     />
                   </svg>
-                  <div className="intro-instructions-container">
-                    <p
-                      className="intro-instructions"
+                  {!hasGeneratedRoutes ? (
+                    <div
+                      className="intro-instructions-container"
                       data-cy="e2e-test-splashpage"
                     >
-                      {hasGeneratedRoutes
-                        ? introMessageRoutes
-                        : introMessageNoRoutes}
-                    </p>
-                    {hasGeneratedRoutes && (
-                      <>
-                        <div className="page-list">
-                          {' '}
-                          Here&apos;s a list of your current pages:
-                        </div>
-                        {routes.map((route) => {
-                          if (!route.props.notfound) {
-                            return (
-                              <div key={route.key}>
-                                <a
-                                  href={route.props.path}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                >
-                                  {route.props.page.name}
-                                </a>
-                              </div>
-                            )
-                          }
-                          return <div key={route.key}></div>
-                        })}
-                      </>
-                    )}
-
-                    {!hasGeneratedRoutes && (
+                      <p className="intro-instructions">
+                        You’re seeing this because you don’t have any pages yet.
+                      </p>
                       <p className="intro-instructions">
                         Type <code>yarn redwood generate page my-page</code> in
                         your CLI to get started!
                       </p>
-                    )}
-                  </div>
+                    </div>
+                  ) : (
+                    <div
+                      className="intro-instructions-container"
+                      data-cy="e2e-test-splashpage"
+                    >
+                      <p className="intro-instructions">
+                        You’re seeing this because you don’t have a page at the{' '}
+                        <code>/</code> path yet.
+                      </p>
+                      <p className="intro-instructions">
+                        Here’s a list of your current pages and their paths:
+                      </p>
+                      <ul className="page-list">
+                        {routes.map((route) => {
+                          if (!route.props.notfound) {
+                            return (
+                              <li key={route.key} className="page-item">
+                                <code>
+                                  {`${route.props.name} -> `}
+                                  <a
+                                    href={route.props.path}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    {route.props.path}
+                                  </a>
+                                </code>
+                              </li>
+                            )
+                          }
+                          return <div key={route.key}></div>
+                        })}
+                      </ul>
+                    </div>
+                  )}
                 </div>
                 <div className="resources">
                   <div className="resource">

--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -9,33 +9,7 @@ const SplashPage: React.VFC<SplashPageProps> = ({
   hasGeneratedRoutes,
   routes,
 }) => {
-  const [version, setVersion] = useState(null)
-  useEffect(() => {
-    async function fetchVersion() {
-      try {
-        const response = await global.fetch(
-          `${global.__REDWOOD__API_PROXY_PATH}/graphql`,
-          {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-            },
-            body: JSON.stringify({
-              query: 'query RedwoodVersion { redwood { version } }',
-            }),
-          }
-        )
-
-        const versionData = await response.json()
-        setVersion(versionData?.data?.redwood?.version || null)
-      } catch (err) {
-        console.error('Unable to get Redwood version: ', err)
-      }
-    }
-
-    fetchVersion()
-  }, [])
-
+  const version = useVersion()
   return (
     <>
       <main>
@@ -552,6 +526,36 @@ const SplashPage: React.VFC<SplashPageProps> = ({
       </main>
     </>
   )
+}
+
+const useVersion = () => {
+  const [version, setVersion] = useState(null)
+  useEffect(() => {
+    async function fetchVersion() {
+      try {
+        const response = await global.fetch(
+          `${global.__REDWOOD__API_PROXY_PATH}/graphql`,
+          {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              query: 'query RedwoodVersion { redwood { version } }',
+            }),
+          }
+        )
+
+        const versionData = await response.json()
+        setVersion(versionData?.data?.redwood?.version || null)
+      } catch (err) {
+        console.error('Unable to get Redwood version: ', err)
+      }
+    }
+
+    fetchVersion()
+  }, [])
+  return version
 }
 
 export { SplashPage }

--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -48,10 +48,12 @@ const SplashPage: React.VFC<SplashPageProps> = ({
               __html: `
             :root {
               --foreground: rgb(26, 32, 44);
-              --secondaryBg: rgb(253, 248, 246);
               --background: hsl(0, 0%, 100%);
+              --background-2: rgb(253, 248, 246);
+              --background-3: rgb(250, 234, 229);
               --highlight-1: rgb(191, 71, 34);
               --highlight-2: rgb(220, 94, 56);
+              --highlight-3: rgba(220, 94, 56, 0.2);
               --space-0: 0.125rem;
               --space-1: 0.25rem;
               --space-2: 0.5rem;
@@ -75,7 +77,8 @@ const SplashPage: React.VFC<SplashPageProps> = ({
               :root {
                 --foreground: hsl(0, 0%, 100%);
                 --background: hsl(250, 24%, 9%);
-                --secondaryBg: hsl(250, 21%, 11%);
+                --background-2: hsl(250, 21%, 11%);
+                --background-3: rgb(53, 37, 32);
               }
             }
 
@@ -146,7 +149,7 @@ const SplashPage: React.VFC<SplashPageProps> = ({
               left: 0%;
               transform: translate(-50%, -50%);
               max-height: 140vh;
-              color: var(--secondaryBg);
+              color: var(--background-2);
             }
 
             /* Intro */
@@ -177,14 +180,14 @@ const SplashPage: React.VFC<SplashPageProps> = ({
 
             code {
               font-family: Fira Code,Fira Mono,Menlo,Monoco,monospace;
-              color: var(--highlight-1);
+              font-size: var(--space-4);
               padding-top: var(--space-0);
               padding-bottom: var(--space-0);
               padding-left: var(--space-1);
               padding-right: var(--space-1);
               border-radius: var(--space-1);
-              background-color: #faeae5;
-              font-size: var(--space-4);
+              color: var(--highlight-2);
+              background-color: var(--highlight-3);
             }
 
             .intro-instructions {
@@ -235,8 +238,11 @@ const SplashPage: React.VFC<SplashPageProps> = ({
             @media (prefers-color-scheme: dark) {
               .resource {
                 color: var(--foreground);
-                background-color: var(--secondaryBg);
+                background-color: var(--background-2);
                 border-color: var(--highlight-1);
+              }
+              .resource:hover {
+                background-color: var(--highlight-3);
               }
             }
 

--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -36,8 +36,8 @@ const SplashPage: React.VFC<SplashPageProps> = ({
     fetchVersion()
   }, [])
 
-  const introMessageNoRoutes = `You're seeing this because you don't have any pages yet.`
-  const introMessageRoutes = `You're seeing this because you don't have a home page yet.`
+  const introMessageNoRoutes = `You’re seeing this because you don’t have any pages yet.`
+  const introMessageRoutes = `You’re seeing this because you don’t have a home page yet.`
 
   return (
     <>

--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -153,21 +153,45 @@ const SplashPage: React.VFC<SplashPageProps> = ({
 
             code {
               font-family: Fira Code,Fira Mono,Menlo,Monoco,monospace;
-              font-size: var(--space-4);
+              font-size: 0.8em;
               padding: var(--space-1) var(--space-2);
               border-radius: var(--space-1);
               color: var(--highlight-2);
               background-color: var(--highlight-3);
             }
 
-            .page-list {
+            .pages {
+              font-size: var(--space-5);
+              line-height: var(--space-7);
+            }
+
+            .pages-title {
+              margin-bottom: var(--space-1);
+              font-weight: 400;
+            }
+
+            .pages-list {
               margin: var(--space-2) 0;
               padding: 0;
               list-style-type: none;
             }
 
-            .page-item {
+            .pages-item {
               margin: var(--space-4) 0;
+            }
+
+            .callout {
+              font-size: var(--space-4);
+              line-height: var(--space-6);
+              font-weight: 400;
+              margin: var(--space-12) auto 0;
+              max-width: 32rem;
+              text-align: left;
+              border-left: 3px solid;
+              border-color: var(--highlight-2);
+              color: var(--foreground);
+              background-color: var(--background-2);
+              padding: var(--space-4);
             }
 
             /* Resources */
@@ -299,34 +323,37 @@ const SplashPage: React.VFC<SplashPageProps> = ({
                       className="intro-instructions-container"
                       data-cy="e2e-test-splashpage"
                     >
-                      <p className="intro-instructions">
+                      <div className="pages">
+                        <p className="pages-title">List of Pages by path:</p>
+                        <ul className="pages-list">
+                          {routes.map((route) => {
+                            if (!route.props.notfound) {
+                              return (
+                                <li key={route.key} className="pages-item">
+                                  <code>
+                                    {`${route.props.name} -> `}
+                                    <a
+                                      href={route.props.path}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                    >
+                                      {route.props.path}
+                                    </a>
+                                  </code>
+                                </li>
+                              )
+                            }
+                            return <div key={route.key}></div>
+                          })}
+                        </ul>
+                      </div>
+                      <div className="callout">
                         You’re seeing this because you don’t have a page at the{' '}
-                        <code>/</code> path yet.
-                      </p>
-                      <p className="intro-instructions">
-                        Here’s a list of your current pages and their paths:
-                      </p>
-                      <ul className="page-list">
-                        {routes.map((route) => {
-                          if (!route.props.notfound) {
-                            return (
-                              <li key={route.key} className="page-item">
-                                <code>
-                                  {`${route.props.name} -> `}
-                                  <a
-                                    href={route.props.path}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                  >
-                                    {route.props.path}
-                                  </a>
-                                </code>
-                              </li>
-                            )
-                          }
-                          return <div key={route.key}></div>
-                        })}
-                      </ul>
+                        <code>/</code> path.
+                        <br />
+                        Type <code>yarn redwood generate page home /</code> in
+                        your CLI to create one.
+                      </div>
                     </div>
                   )}
                 </div>

--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -79,6 +79,10 @@ const SplashPage: React.VFC<SplashPageProps> = ({
               }
             }
 
+            html, body {
+              margin: 0;
+            }
+
             .container {
               font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
                 "Helvetica Neue", Arial, "Noto Sans", sans-serif;
@@ -123,12 +127,16 @@ const SplashPage: React.VFC<SplashPageProps> = ({
             }
 
             /* Content */
-            .content {
-              position: relative;
-              padding: 0 var(--space-5);
+            .content-container {
               flex-grow: 1;
               display: flex;
               justify-content: center;
+              align-items: center;
+            }
+
+            .content {
+              padding: var(--space-5) var(--space-5) var(--space-8);
+              position: relative;
             }
 
             /* Logo */
@@ -144,7 +152,6 @@ const SplashPage: React.VFC<SplashPageProps> = ({
             /* Intro */
             .intro {
               text-align: center;
-              margin-top: var(--space-16);
               margin-bottom: var(--space-18);
             }
 
@@ -270,8 +277,8 @@ const SplashPage: React.VFC<SplashPageProps> = ({
               />
             </svg>
 
-            <section className="content">
-              <div>
+            <section className="content-container">
+              <div className="content">
                 <div className="intro">
                   <h1 className="intro-heading">Welcome to</h1>
                   <svg


### PR DESCRIPTION
This MR address comments about the information architecture of the second splash screen. It also moves the useVersion useEffect hook into it's own hook to simplify the component.
- Minor layout and styling tweaks
- Prioritisation of page list
- Creation of callout styles

![image](https://user-images.githubusercontent.com/2268424/134291824-c3195fee-e3ad-481c-b26f-b42e205820d3.png)
![image](https://user-images.githubusercontent.com/2268424/134291839-6b01d223-422d-485c-a4db-634c01300cd7.png)
